### PR TITLE
[#86] apply details tag marker none

### DIFF
--- a/src/styles/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle.tsx
@@ -54,6 +54,10 @@ const globalStyle = (theme: Theme) => css`
     list-style: none;
   }
 
+  details > summary::-webkit-details-marker {
+    display: none;
+  }
+
   summary {
     all: unset;
     cursor: pointer;
@@ -66,7 +70,6 @@ const globalStyle = (theme: Theme) => css`
   ul,
   li {
     all: unset;
-    list-style-type: none;
     list-style: none;
   }
 

--- a/src/styles/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle.tsx
@@ -61,16 +61,7 @@ const globalStyle = (theme: Theme) => css`
   summary {
     all: unset;
     cursor: pointer;
-    -webkit-user-select: none;
-    user-select: none;
-    list-style: none;
     outline: none;
-  }
-
-  ul,
-  li {
-    all: unset;
-    list-style: none;
   }
 
   h1,


### PR DESCRIPTION
### 설명

details 태그의 삼각형 아이콘을 제거하였습니다.

### 중점적으로 봐줬으면 좋을 부분

모든 브라우저가 summary 요소의 전체 기능을 지원하지 않아 비표준 CSS 의사 요소 ::-webkit-details-marker 를 통해 아이콘 표시를 제어하였습니다.

```css

details > summary::-webkit-details-marker {
  display: none;
}

```