### PR TITLE
[#96] apply Image span border-radius

### DIFF
--- a/src/components/Card/PlaceCard.tsx
+++ b/src/components/Card/PlaceCard.tsx
@@ -1,8 +1,8 @@
 import { css, Theme } from "@emotion/react";
+import { defaultFadeInUpVariants } from "constants/motion";
+import { motion } from "framer-motion";
 import Image from "next/image";
 import Link from "next/link";
-import { motion } from "framer-motion";
-import { defaultFadeInUpVariants } from "constants/motion";
 
 interface Props {
   id?: number;
@@ -63,6 +63,9 @@ const imgWrapper = css`
   position: relative;
   width: 9.8rem;
   height: 12.2rem;
+  span {
+    border-radius: 5px;
+  }
 `;
 
 const placeImg = css`

--- a/src/components/Detail/Menu/MenuList.tsx
+++ b/src/components/Detail/Menu/MenuList.tsx
@@ -21,21 +21,25 @@ function MenuList({ name, price, menuImage, description }: Props) {
         </div>
         <div css={imgWrapper}>
           {menuImage?.id ? (
-            <Image
-              src={`${API_BASE_URL}/api/images/${menuImage?.id}`}
-              alt="menu img"
-              layout="fill"
-              css={menuImg}
-              priority
-            />
+            <div css={imgBorder}>
+              <Image
+                src={`${API_BASE_URL}/api/images/${menuImage?.id}`}
+                alt="menu img"
+                layout="fill"
+                css={menuImg}
+                priority
+              />
+            </div>
           ) : (
-            <Image
-              src="/images/noImage.png"
-              alt="Image in preparation"
-              layout="fill"
-              css={menuImg}
-              priority
-            />
+            <div css={imgBorder}>
+              <Image
+                src="/images/noImage.png"
+                alt="Image in preparation"
+                layout="fill"
+                css={menuImg}
+                priority
+              />
+            </div>
           )}
         </div>
       </div>
@@ -63,11 +67,18 @@ const summaryWrapper = css`
   flex-direction: column;
 `;
 
+const imgBorder = css`
+  span {
+    border-radius: 0.6rem;
+  }
+`;
+
 const imgWrapper = css`
   position: relative;
   min-width: 8.3rem;
   width: 8.3rem;
   height: 7.5rem;
+  border-radius: 0.6rem;
 `;
 
 const menuImg = css`

--- a/src/pages/Detail/[detailId].tsx
+++ b/src/pages/Detail/[detailId].tsx
@@ -106,6 +106,8 @@ const imgSize = css`
   position: absolute;
   width: 100%;
   height: 100%;
+  object-fit: cover;
+  overflow: hidden;
 `;
 
 const informWrapper = css`


### PR DESCRIPTION
## Description

- 모바일 환경이나 safari, firefox에선 잘 작동하나 크롬 환경에서 img에 css가 적용되지 않았습니다.
- span 태그에 css를 주어 해결하였습니다.

## Important content

- next.js 13버전에서는 next/Image의 span이 없어 이 문제가 발생하지 않지만 온수냠냠냠은 이전 버전이기에 특정 환경에서는 이러한 문제가 발생하였습니다.

### 크롬
<img width="28%" alt="스크린샷 2023-03-09 오후 11 32 18" src="https://user-images.githubusercontent.com/63100352/224062387-11591ece-18c1-4c30-a64f-1a02c7c21d44.png">

### safari
<img width="28%" alt="스크린샷 2023-03-09 오후 11 31 53" src="https://user-images.githubusercontent.com/63100352/224062397-71bfe7a3-ff58-403e-ac93-0c4b0ffcf9a2.png">